### PR TITLE
Fix Makefile paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ build:
 
 # Initialize the SQLite database
 init-db:
-	sqlite3 clidblocal.db < src/init.sql
+	sqlite3 clidblocal.db < sql/init.sql
 
 # Run the built binary
 start:
-	target/debug/cliNotes
+	target/debug/CliNotes
 
 clean:
 	cargo clean


### PR DESCRIPTION
## Summary
- update init-db path to `sql/init.sql`
- run the correct binary in `start`
- restore tabs for Makefile commands

## Testing
- `make init-db`